### PR TITLE
Added libboost-graph-dev to Ubuntu dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ included with `p4c` are documented here:
 
 Most dependencies can be installed using `apt-get install`:
 
-`sudo apt-get install g++ git automake libtool libgc-dev bison flex libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev pkg-config python python-scapy python-ipaddr tcpdump cmake`
+`sudo apt-get install g++ git automake libtool libgc-dev bison flex libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev libboost-graph-dev pkg-config python python-scapy python-ipaddr tcpdump cmake`
 
 For documentation building:
 `sudo apt-get install -y doxygen graphviz texlive-full`


### PR DESCRIPTION
Fixes the CMake warning: "Boost graph headers not found, will not build 'graphs' backend" and thus builds the graphs backend.